### PR TITLE
Add usage event support

### DIFF
--- a/0001-UBUNTU-SAUCE-track-active-readers.patch
+++ b/0001-UBUNTU-SAUCE-track-active-readers.patch
@@ -1,0 +1,97 @@
+From abe07ef8c714e28cca05cd704fecd1fb68c47bae Mon Sep 17 00:00:00 2001
+From: Dimitri John Ledkov <dimitri.ledkov@canonical.com>
+Date: Thu, 6 Oct 2022 15:01:47 +0100
+Subject: [PATCH 1/2] UBUNTU: SAUCE: track active readers
+
+Gbp-Pq: 0005-track-active-readers.patch.
+---
+ v4l2loopback.c | 34 +++++++++++++++++++++++++++++-----
+ 1 file changed, 29 insertions(+), 5 deletions(-)
+
+diff --git a/v4l2loopback.c b/v4l2loopback.c
+index 7e47a43..77291bc 100644
+--- a/v4l2loopback.c
++++ b/v4l2loopback.c
+@@ -379,6 +379,7 @@ struct v4l2_loopback_device {
+ 	int ready_for_output; /* set to true when no writer is currently attached
+ 			       * this differs slightly from !ready_for_capture,
+ 			       * e.g. when using fallback images */
++	int active_readers;   /* increase if any reader starts streaming */
+ 	int announce_all_caps; /* set to false, if device caps (OUTPUT/CAPTURE)
+ 			       * should only be announced if the resp. "ready"
+ 			       * flag is set; default=TRUE */
+@@ -1740,9 +1741,10 @@ static int vidioc_streamon(struct file *file, void *fh, enum v4l2_buf_type type)
+ 		}
+ 		return 0;
+ 	case V4L2_BUF_TYPE_VIDEO_CAPTURE:
+-		opener->type = READER;
+ 		if (!dev->ready_for_capture)
+ 			return -EIO;
++		opener->type = READER;
++		dev->active_readers++;
+ 		return 0;
+ 	default:
+ 		return -EINVAL;
+@@ -1756,8 +1758,27 @@ static int vidioc_streamon(struct file *file, void *fh, enum v4l2_buf_type type)
+ static int vidioc_streamoff(struct file *file, void *fh,
+ 			    enum v4l2_buf_type type)
+ {
++	struct v4l2_loopback_device *dev;
++	struct v4l2_loopback_opener *opener;
++
+ 	MARK();
+ 	dprintk("%d\n", type);
++
++	dev = v4l2loopback_getdevice(file);
++	opener = fh_to_opener(fh);
++	switch (type) {
++	case V4L2_BUF_TYPE_VIDEO_OUTPUT:
++		break;
++	case V4L2_BUF_TYPE_VIDEO_CAPTURE:
++		if (opener->type == READER) {
++			opener->type = 0;
++			dev->active_readers--;
++		}
++		break;
++	default:
++		return -EINVAL;
++	}
++
+ 	return 0;
+ }
+ 
+@@ -1980,14 +2001,16 @@ static int v4l2_loopback_close(struct file *file)
+ {
+ 	struct v4l2_loopback_opener *opener;
+ 	struct v4l2_loopback_device *dev;
+-	int iswriter = 0;
++	int is_writer = 0, is_reader = 0;
+ 	MARK();
+ 
+ 	opener = fh_to_opener(file->private_data);
+ 	dev = v4l2loopback_getdevice(file);
+ 
+ 	if (WRITER == opener->type)
+-		iswriter = 1;
++		is_writer = 1;
++	if (READER == opener->type)
++		is_reader = 1;
+ 
+ 	atomic_dec(&dev->open_count);
+ 	if (dev->open_count.counter == 0) {
+@@ -2000,9 +2023,10 @@ static int v4l2_loopback_close(struct file *file)
+ 	v4l2_fh_exit(&opener->fh);
+ 
+ 	kfree(opener);
+-	if (iswriter) {
++	if (is_writer)
+ 		dev->ready_for_output = 1;
+-	}
++	if (is_reader)
++		dev->active_readers--;
+ 	MARK();
+ 	return 0;
+ }
+-- 
+2.38.1
+

--- a/0002-UBUNTU-SAUCE-event-support-V4L2_EVENT_PRI_CLIENT_USA.patch
+++ b/0002-UBUNTU-SAUCE-event-support-V4L2_EVENT_PRI_CLIENT_USA.patch
@@ -1,0 +1,129 @@
+From 077e0aa50d3dfffc18731740068e8e59e30c6fc8 Mon Sep 17 00:00:00 2001
+From: Dimitri John Ledkov <dimitri.ledkov@canonical.com>
+Date: Thu, 6 Oct 2022 15:01:47 +0100
+Subject: [PATCH 2/2] UBUNTU: SAUCE: event: support V4L2_EVENT_PRI_CLIENT_USAGE
+
+Gbp-Pq: 0006-UBUNTU-SAUCE-event-support-V4L2_EVENT_PRI_CLIENT_USA.patch.
+---
+ v4l2loopback.c | 63 +++++++++++++++++++++++++++++++++++++++++++++++++-
+ 1 file changed, 62 insertions(+), 1 deletion(-)
+
+diff --git a/v4l2loopback.c b/v4l2loopback.c
+index 77291bc..8d3a22c 100644
+--- a/v4l2loopback.c
++++ b/v4l2loopback.c
+@@ -632,6 +632,14 @@ static void v4l2loopback_create_sysfs(struct video_device *vdev)
+ 	dev_err(&vdev->dev, "%s error: %d\n", __func__, res);
+ }
+ 
++/* Event APIs */
++
++#define V4L2_EVENT_PRI_CLIENT_USAGE  V4L2_EVENT_PRIVATE_START
++
++struct v4l2_event_client_usage {
++	__u32 count;
++};
++
+ /* global module data */
+ struct v4l2_loopback_device *devs[MAX_DEVICES];
+ 
+@@ -664,6 +672,7 @@ static struct v4l2_loopback_device *v4l2loopback_getdevice(struct file *f)
+ }
+ 
+ /* forward declarations */
++static void client_usage_queue_event(struct video_device *vdev);
+ static void init_buffers(struct v4l2_loopback_device *dev);
+ static int allocate_buffers(struct v4l2_loopback_device *dev);
+ static int free_buffers(struct v4l2_loopback_device *dev);
+@@ -1745,6 +1754,7 @@ static int vidioc_streamon(struct file *file, void *fh, enum v4l2_buf_type type)
+ 			return -EIO;
+ 		opener->type = READER;
+ 		dev->active_readers++;
++		client_usage_queue_event(dev->vdev);
+ 		return 0;
+ 	default:
+ 		return -EINVAL;
+@@ -1773,6 +1783,7 @@ static int vidioc_streamoff(struct file *file, void *fh,
+ 		if (opener->type == READER) {
+ 			opener->type = 0;
+ 			dev->active_readers--;
++			client_usage_queue_event(dev->vdev);
+ 		}
+ 		break;
+ 	default:
+@@ -1797,12 +1808,60 @@ static int vidiocgmbuf(struct file *file, void *fh, struct video_mbuf *p)
+ }
+ #endif
+ 
++static void client_usage_queue_event(struct video_device *vdev)
++{
++	struct v4l2_event ev;
++	struct v4l2_loopback_device *dev;
++
++	dev = container_of(vdev->v4l2_dev,
++			   struct v4l2_loopback_device, v4l2_dev);
++
++	memset(&ev, 0, sizeof(ev));
++	ev.type = V4L2_EVENT_PRI_CLIENT_USAGE;
++	((struct v4l2_event_client_usage*)&ev.u)->count =
++		dev->active_readers;
++
++	v4l2_event_queue(vdev, &ev);
++}
++
++static int client_usage_ops_add(struct v4l2_subscribed_event *sev,
++				unsigned elems)
++{
++	if (!(sev->flags & V4L2_EVENT_SUB_FL_SEND_INITIAL))
++		return 0;
++
++	client_usage_queue_event(sev->fh->vdev);
++	return 0;
++}
++
++static void client_usage_ops_replace(struct v4l2_event *old,
++				     const struct v4l2_event *new)
++{
++	*((struct v4l2_event_client_usage*)&old->u) =
++		*((struct v4l2_event_client_usage*)&new->u);
++}
++
++static void client_usage_ops_merge(const struct v4l2_event *old,
++				   struct v4l2_event *new)
++{
++	*((struct v4l2_event_client_usage*)&new->u) =
++		*((struct v4l2_event_client_usage*)&old->u);
++}
++
++const struct v4l2_subscribed_event_ops client_usage_ops = {
++	.add = client_usage_ops_add,
++	.replace = client_usage_ops_replace,
++	.merge = client_usage_ops_merge,
++};
++
+ static int vidioc_subscribe_event(struct v4l2_fh *fh,
+ 				  const struct v4l2_event_subscription *sub)
+ {
+ 	switch (sub->type) {
+ 	case V4L2_EVENT_CTRL:
+ 		return v4l2_ctrl_subscribe_event(fh, sub);
++	case V4L2_EVENT_PRI_CLIENT_USAGE:
++		return v4l2_event_subscribe(fh, sub, 0, &client_usage_ops);
+ 	}
+ 
+ 	return -EINVAL;
+@@ -2025,8 +2084,10 @@ static int v4l2_loopback_close(struct file *file)
+ 	kfree(opener);
+ 	if (is_writer)
+ 		dev->ready_for_output = 1;
+-	if (is_reader)
++	if (is_reader) {
+ 		dev->active_readers--;
++		client_usage_queue_event(dev->vdev);
++	}
+ 	MARK();
+ 	return 0;
+ }
+-- 
+2.38.1
+

--- a/v4l2loopback-kmod.spec
+++ b/v4l2loopback-kmod.spec
@@ -22,6 +22,17 @@ Source0:        %{url}/archive/v%{version}/%{prjname}-%{version}.tar.gz
 # Submitted upstream: https://github.com/umlaeute/v4l2loopback/pull/389
 Patch0:         v4l2loopback-0.12.3-Include-header-outside-of-struct-definition.patch
 
+# These two patches are from ubuntu and is used to usage count to the
+# application. This is important for IPU6 v4l2loopback solution since
+# the application opens v4l2loopback rather than an IPU6 device. The
+# streaming relay application needs this information to determine whether
+# to continue or stop the video streaming from IPU6.
+
+# https://git.launchpad.net/ubuntu/+source/v4l2loopback/patch/?id=abe07ef8c714e28cca05cd704fecd1fb68c47bae
+patch1:         0001-UBUNTU-SAUCE-track-active-readers.patch
+# https://git.launchpad.net/ubuntu/+source/v4l2loopback/patch/?id=077e0aa50d3dfffc18731740068e8e59e30c6fc8
+patch2:         0002-UBUNTU-SAUCE-event-support-V4L2_EVENT_PRI_CLIENT_USA.patch
+
 BuildRequires:  gcc
 BuildRequires:  elfutils-libelf-devel
 BuildRequires:  kmodtool
@@ -49,6 +60,8 @@ kmodtool  --target %{_target_cpu} --repo rpmfusion --kmodname %{prjname} %{?buil
 %setup -q -c
 (cd v4l2loopback-%{version}
 %patch0 -p1
+%patch1 -p1
+%patch2 -p1
 )
 
 for kernel_version  in %{?kernel_versions} ; do
@@ -72,6 +85,9 @@ done
 
 
 %changelog
+*Tue Dec 13 2022 Kate Hsuan <hpa@redhat.com> - 0.12.7-3
+- Add usage event
+
 * Mon Aug 08 2022 RPM Fusion Release Engineering <sergiomb@rpmfusion.org> - 0.12.7-2
 - Rebuilt for https://fedoraproject.org/wiki/Fedora_37_Mass_Rebuild and ffmpeg
   5.1


### PR DESCRIPTION
These two patches [1-2] from Canonical implement the V4L2_EVENT_PRI_CLIENT_USAGE which allows the application knows the device usage. This is used for IPU6 v4l2loopback solution since the application actually opens v4l2loopback device rather than an IPU6 device. This usage event is needed to deliver the usage to the streaming relay application. According to the usage count, the relay application determines whether to continue or stop video streaming from IPU6 and controls the power status of the image sensor.

[1] https://git.launchpad.net/ubuntu/+source/v4l2loopback/patch/?id=abe07ef8c714e28cca05cd704fecd1fb68c47bae

 [2] https://git.launchpad.net/ubuntu/+source/v4l2loopback/patch/?id=077e0aa50d3dfffc18731740068e8e59e30c6fc8

Signed-off-by: Kate Hsuan <hpa@redhat.com>